### PR TITLE
Fix issue when empty section was in the end. Resolves #9

### DIFF
--- a/src/main/kotlin/cz/ackee/localizer/model/XmlGenerator.kt
+++ b/src/main/kotlin/cz/ackee/localizer/model/XmlGenerator.kt
@@ -30,7 +30,7 @@ class XmlGenerator(val resPath: String, val defaultLang: String = "en") {
             resource.entries.forEachIndexed { index, entry ->
                 when (entry) {
                     is Localization.Resource.Entry.Section -> {
-                        if (resource.entries[index + 1] is Localization.Resource.Entry.Section) {
+                        if (index > resource.entries.lastIndex || resource.entries[index + 1] is Localization.Resource.Entry.Section) {
                             return@forEachIndexed
                         }
                         appendln()


### PR DESCRIPTION
Because index + 1 entry was checked it crashed when this was outside
the bounds of the array. Skip this section if that happens.