### PR TITLE
Fix out of bounds exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ group 'cz.ackee.localizer'
 version '0.9.9'
 
 buildscript {
-    ext.kotlin_version = '1.3.60'
+    ext.kotlin_version = '1.3.61'
 
     repositories {
         jcenter()

--- a/src/main/kotlin/cz/ackee/localizer/model/XmlGenerator.kt
+++ b/src/main/kotlin/cz/ackee/localizer/model/XmlGenerator.kt
@@ -30,7 +30,7 @@ class XmlGenerator(val resPath: String, val defaultLang: String = "en") {
             resource.entries.forEachIndexed { index, entry ->
                 when (entry) {
                     is Localization.Resource.Entry.Section -> {
-                        if (index > resource.entries.lastIndex || resource.entries[index + 1] is Localization.Resource.Entry.Section) {
+                        if (index == resource.entries.lastIndex || resource.entries[index + 1] is Localization.Resource.Entry.Section) {
                             return@forEachIndexed
                         }
                         appendln()

--- a/src/main/kotlin/cz/ackee/localizer/model/XmlGenerator.kt
+++ b/src/main/kotlin/cz/ackee/localizer/model/XmlGenerator.kt
@@ -30,9 +30,6 @@ class XmlGenerator(val resPath: String, val defaultLang: String = "en") {
             resource.entries.forEachIndexed { index, entry ->
                 when (entry) {
                     is Localization.Resource.Entry.Section -> {
-                        if (index == resource.entries.lastIndex || resource.entries[index + 1] is Localization.Resource.Entry.Section) {
-                            return@forEachIndexed
-                        }
                         appendln()
                         appendln()
                         append(INDENT)
@@ -80,6 +77,10 @@ class XmlGenerator(val resPath: String, val defaultLang: String = "en") {
     private fun String.format() =
             this
                     .replace("'", "\\'")
-                    .replace("\"", "\\\"")
+                    .apply {
+                        if (!contains("CDATA")) {
+                            replace("\"", "\\\"")
+                        }
+                    }
                     .replace("&(?!.{2,4};)".toRegex(), "&amp;")
 }


### PR DESCRIPTION
To make generation of empty sections consistent
remove the check for the last empty section that caused the exception. Also create
test for that. Also there was unsuccessful test so this
commit will fix it.